### PR TITLE
Rm prefix for LinkedIn link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -102,7 +102,7 @@ author:
   instagram        :
   impactstory      : #"https://profiles.impactstory.org/u/xxxx-xxxx-xxxx-xxxx"
   lastfm           :
-  linkedin         :  "https://www.linkedin.com/in/faryaneh-poursardar"
+  linkedin         :  "faryaneh-poursardar"
   orcid            : #"http://orcid.org/yourorcidurl"
   pinterest        :
   soundcloud       :


### PR DESCRIPTION
@Faryaneh The hyperlink to your LinkedIn profile at https://faryaneh.github.io/ is preceded with a superfluous path -- just the LinkedIn username needs to be specified in the configuration. This PR fixes that in the config to ultimately fix the link. Compare the LinkedIn link at https://machawk1.github.io/Faryaneh.github.io/ vs. https://faryaneh.github.io/ for validation.